### PR TITLE
Add new browser task to grinder rules

### DIFF
--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -49,7 +49,10 @@ deploy() {
 @Depends(build)
 browser() {
   try {
-    run('hash', arguments: ['dartium']);
+    run('dartium', arguments: [
+      webDir.absolute.path + '/index.html',
+      '--disable-web-security'
+    ]);
   } catch (processException) {
     runAsync('pub', arguments: ['serve']);
     run('open', arguments: [

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -50,8 +50,15 @@ deploy() {
 browser() {
   try {
     run('hash', arguments: ['dartium']);
-  } catch(processException) {
+  } catch (processException) {
     runAsync('pub', arguments: ['serve']);
-    run('open', arguments: ['-a', 'Google Chrome', '--args', 'http://localhost:8080', '--disable-web-security', '--user-data-dir']);
+    run('open', arguments: [
+      '-a',
+      'Google Chrome',
+      '--args',
+      'http://localhost:8080',
+      '--disable-web-security',
+      '--user-data-dir'
+    ]);
   }
 }

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -44,3 +44,14 @@ build() {
 deploy() {
   run('surge', arguments: ['-d', 'which-film.info', '-p', 'build/web']);
 }
+
+@Task('Run in browser.')
+@Depends(build)
+browser() {
+  try {
+    run('hash', arguments: ['dartium']);
+  } catch(processException) {
+    runAsync('pub', arguments: ['serve']);
+    run('open', arguments: ['-a', 'Google Chrome', '--args', 'http://localhost:8080', '--disable-web-security', '--user-data-dir']);
+  }
+}


### PR DESCRIPTION
Add new (dartium) browser task to grinder rules, with Google Chrome fallback (Closes #49)
